### PR TITLE
Fixing bug with var names in websocket service

### DIFF
--- a/Telemachus/src/KSPWebSocketService.cs
+++ b/Telemachus/src/KSPWebSocketService.cs
@@ -82,7 +82,7 @@ namespace Telemachus
 
                                 if (entry != null)
                                 {
-                                    dataSources.setVarName(trimedQuotes);
+                                    dataSourcesClone.setVarName(trimedQuotes);
                                     entries.Add(entry.formatter.format(entry.function(dataSourcesClone), dataSourcesClone.getVarName()));
                                 }
                             }


### PR DESCRIPTION
This bug was introduced in commit 3dd01819999f9685ed1b536df89e2c95364080ff. It causes the first data point in the response to have no label, thus invalid json, and every subsequent data point to have the label from the previous data point. 

This should fix that. Thanks!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/captncraig/telemachus/1)

<!-- Reviewable:end -->
